### PR TITLE
Fix macOS tray tooltip not showing sync status

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2013 ownCloud GmbH
  * SPDX-License-Identifier: GPL-2.0-or-later
@@ -359,7 +360,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
         for (const AccountStatePtr &a : problemAccounts) {
             accountNames.append(a->account()->displayName());
         }
-        _tray->setToolTip(tr("Disconnected from %1").arg(accountNames.join(QLatin1String(", "))));
+        _tray->setTrayToolTip(tr("Disconnected from %1").arg(accountNames.join(QLatin1String(", "))));
 #else
         QStringList messages;
         messages.append(tr("Disconnected from accounts:"));
@@ -371,18 +372,18 @@ void ownCloudGui::slotComputeOverallSyncStatus()
             }
             messages.append(message);
         }
-        _tray->setToolTip(messages.join(QLatin1String("\n\n")));
+        _tray->setTrayToolTip(messages.join(QLatin1String("\n\n")));
 #endif
         return;
     }
 
     if (allSignedOut) {
         _tray->setIcon(Theme::instance()->folderOfflineIcon(true));
-        _tray->setToolTip(tr("Please sign in"));
+        _tray->setTrayToolTip(tr("Please sign in"));
         return;
     } else if (allPaused) {
         _tray->setIcon(Theme::instance()->syncStateIcon(SyncResult::Paused, true));
-        _tray->setToolTip(tr("Account synchronization is disabled"));
+        _tray->setTrayToolTip(tr("Account synchronization is disabled"));
         return;
     }
 
@@ -462,9 +463,9 @@ void ownCloudGui::slotComputeOverallSyncStatus()
 #endif
         trayMessage = allStatusStrings.join(QLatin1String("\n"));
 #endif
-        _tray->setToolTip(trayMessage);
+        _tray->setTrayToolTip(trayMessage);
     } else {
-        _tray->setToolTip(tr("There are no sync folders configured."));
+        _tray->setTrayToolTip(tr("There are no sync folders configured."));
     }
 }
 

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2013 ownCloud GmbH
  * SPDX-License-Identifier: GPL-2.0-or-later
@@ -54,6 +55,15 @@ Systray *Systray::instance()
 QQmlApplicationEngine *Systray::trayEngine() const
 {
     return _trayEngine.get();
+}
+
+void Systray::setTrayToolTip(const QString &toolTip)
+{
+    QSystemTrayIcon::setToolTip(toolTip);
+
+#ifdef Q_OS_MACOS
+    setStatusItemToolTip(this, toolTip);
+#endif
 }
 
 void Systray::setTrayEngine(QQmlApplicationEngine *trayEngine)

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2013 ownCloud GmbH
  * SPDX-License-Identifier: GPL-2.0-or-later
@@ -45,6 +46,7 @@ bool canOsXSendUserNotification();
 void sendOsXUserNotification(const QString &title, const QString &message);
 void sendOsXUpdateNotification(const QString &title, const QString &message, const QUrl &webUrl);
 void sendOsXTalkNotification(const QString &title, const QString &message, const QString &token, const QString &replyTo, const AccountStatePtr accountState);
+void setStatusItemToolTip(QSystemTrayIcon *trayIcon, const QString &toolTip);
 #endif
 void setTrayWindowLevelAndVisibleOnAllSpaces(QWindow *window);
 double menuBarThickness();
@@ -93,6 +95,8 @@ public:
     bool raiseDialogs();
 
     [[nodiscard]] QQmlApplicationEngine* trayEngine() const;
+
+    void setTrayToolTip(const QString &toolTip);
 
 signals:
     void currentUserChanged();

--- a/src/gui/systray_mac_common.mm
+++ b/src/gui/systray_mac_common.mm
@@ -1,15 +1,87 @@
 /*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <QWindow>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QtCore/qrect.h>
+#include <QtCore/qstring.h>
+
+#include <cmath>
 
 #import <Cocoa/Cocoa.h>
 
 #include "systray.h"
 
 Q_LOGGING_CATEGORY(lcMacSystrayCommon, "nextcloud.gui.macsystraycommon")
+
+namespace {
+
+CGRect qtGeometryToCocoaRect(const QRect &geometry)
+{
+    if (!geometry.isValid()) {
+        return CGRectNull;
+    }
+
+    QScreen *screen = QGuiApplication::screenAt(geometry.center());
+    if (!screen) {
+        screen = QGuiApplication::primaryScreen();
+    }
+
+    if (!screen) {
+        return CGRectNull;
+    }
+
+    const QRect screenGeometry = screen->geometry();
+
+    const CGFloat originX = geometry.x();
+    const CGFloat originY = screenGeometry.y() + screenGeometry.height() - geometry.y() - geometry.height();
+
+    return CGRectMake(originX, originY, geometry.width(), geometry.height());
+}
+
+NSStatusItem *statusItemForTrayIcon(QSystemTrayIcon *trayIcon)
+{
+    if (!trayIcon) {
+        return nil;
+    }
+
+    const CGRect desiredFrame = qtGeometryToCocoaRect(trayIcon->geometry());
+    if (CGRectIsNull(desiredFrame)) {
+        return nil;
+    }
+
+    NSArray *statusItems = [[NSStatusBar systemStatusBar] valueForKey:@"_statusItems"];
+    if (![statusItems isKindOfClass:[NSArray class]]) {
+        return nil;
+    }
+
+    for (NSStatusItem *statusItem in statusItems) {
+        NSStatusBarButton *button = statusItem.button;
+        if (!button) {
+            continue;
+        }
+
+        NSWindow *window = button.window;
+        if (!window) {
+            continue;
+        }
+
+        const CGRect windowFrame = NSRectToCGRect(window.frame);
+
+        if (std::abs(windowFrame.origin.x - desiredFrame.origin.x) <= 1.0 &&
+            std::abs(windowFrame.origin.y - desiredFrame.origin.y) <= 1.0) {
+            return statusItem;
+        }
+    }
+
+    return nil;
+}
+
+} // anonymous namespace
 
 namespace OCC {
 
@@ -41,6 +113,22 @@ bool osXInDarkMode()
 {
     NSString * const osxMode = [NSUserDefaults.standardUserDefaults stringForKey:@"AppleInterfaceStyle"];
     return [osxMode containsString:@"Dark"];
+}
+
+void setStatusItemToolTip(QSystemTrayIcon *trayIcon, const QString &toolTip)
+{
+    static bool warnedOnce = false;
+
+    NSStatusItem * const statusItem = statusItemForTrayIcon(trayIcon);
+    if (!statusItem) {
+        if (!warnedOnce) {
+            warnedOnce = true;
+            qCWarning(lcMacSystrayCommon) << "Unable to find NSStatusItem for tray icon, tooltip update skipped.";
+        }
+        return;
+    }
+
+    statusItem.button.toolTip = toolTip.isEmpty() ? nil : toolTip.toNSString();
 }
 
 }


### PR DESCRIPTION
## Summary
- ensure the tray tooltip setter also updates the underlying NSStatusItem on macOS
- expose a Systray helper for tooltip updates and route sync status strings through it

## Testing
- not run (macOS-specific change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690da0ac5b788333bc6083932628e170)