### PR TITLE
fix: align add account icon in tray menu on macOS

### DIFF
--- a/src/gui/tray/CurrentAccountHeaderButton.qml
+++ b/src/gui/tray/CurrentAccountHeaderButton.qml
@@ -127,23 +127,57 @@ Button {
 
             readonly property real addAccountIconSize: Style.accountAvatarSize * Style.smallIconScaleFactor
             readonly property real addAccountHorizontalOffset: ( (Style.accountAvatarSize - addAccountIconSize) / 2 ) + Style.accountIconsMenuMargin
+            readonly property string addAccountIconSource: "image://svgimage-custom-color/add.svg/" + iconColor
             property var iconColor: !addAccountButton.enabled
                                     ? addAccountButton.palette.mid
                                     : ((addAccountButton.highlighted || addAccountButton.down) && Qt.platform.os !== "windows"
                                         ? addAccountButton.palette.highlightedText
                                         : addAccountButton.palette.text)
 
-            icon.source: "image://svgimage-custom-color/add.svg/" + iconColor
-            icon.width: addAccountIconSize
-            icon.height: addAccountIconSize
-            leftPadding: addAccountHorizontalOffset
-            spacing: Style.userLineSpacing
+            leftPadding: 0
+            rightPadding: 0
+            topPadding: 0
+            bottomPadding: 0
             text: qsTr("Add account")
             onClicked: UserModel.addAccount()
 
             Accessible.role: Accessible.MenuItem
             Accessible.name: qsTr("Add new account")
             Accessible.onPressAction: addAccountButton.clicked()
+
+            contentItem: Item {
+                implicitHeight: Style.trayWindowHeaderHeight
+                implicitWidth: addAccountButton.addAccountHorizontalOffset
+                                + addAccountButton.addAccountIconSize
+                                + Style.userLineSpacing
+                                + addAccountLabel.implicitWidth
+
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: addAccountButton.addAccountHorizontalOffset
+                    spacing: Style.userLineSpacing
+
+                    Image {
+                        source: addAccountButton.addAccountIconSource
+                        sourceSize.width: addAccountButton.addAccountIconSize
+                        sourceSize.height: addAccountButton.addAccountIconSize
+                        Layout.preferredWidth: addAccountButton.addAccountIconSize
+                        Layout.preferredHeight: addAccountButton.addAccountIconSize
+                        Layout.alignment: Qt.AlignVCenter
+                    }
+
+                    Text {
+                        id: addAccountLabel
+                        text: addAccountButton.text
+                        horizontalAlignment: Text.AlignLeft
+                        verticalAlignment: Text.AlignVCenter
+                        elide: Text.ElideRight
+                        font: addAccountButton.font
+                        Layout.alignment: Qt.AlignVCenter
+                        color: addAccountButton.iconColor
+                    }
+                }
+            }
         }
 
         MenuSeparator {}

--- a/src/gui/tray/CurrentAccountHeaderButton.qml
+++ b/src/gui/tray/CurrentAccountHeaderButton.qml
@@ -123,6 +123,8 @@ Button {
             id: addAccountButton
             hoverEnabled: true
             visible: Systray.enableAddAccount
+            height: visible ? implicitHeight : 0
+            enabled: visible
             implicitHeight: Style.trayWindowHeaderHeight
 
             readonly property real addAccountIconSize: Style.accountAvatarSize * Style.smallIconScaleFactor


### PR DESCRIPTION
### Motivation
- On macOS the plus icon in the tray `Add account` menu item was vertically misaligned with the user avatars while other platforms rendered correctly. 
- The goal is to align the add-account icon consistently with account avatar sizing and spacing so the tray menu looks consistent across platforms.

### Description
- Replaced the `MenuItem` icon usage in `src/gui/tray/CurrentAccountHeaderButton.qml` with a custom `contentItem` containing a `RowLayout` that explicitly places an `Image` and `Text` side-by-side. 
- Added `addAccountIconSource` and reused existing `addAccountIconSize` and `addAccountHorizontalOffset` to compute icon sizing and left offset consistent with account avatars. 
- Removed the `MenuItem` internal paddings and set the label `font` and `color` to use the `addAccountButton` properties to preserve highlighting and disabled coloring behavior.

### Testing
- No automated tests were run because this is a visual UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69576c8d0d9c8333bbc6b4dab5b6fb24)