### PR TITLE
fix: overlay sync issues on account avatars

### DIFF
--- a/src/gui/tray/CurrentAccountHeaderButton.qml
+++ b/src/gui/tray/CurrentAccountHeaderButton.qml
@@ -273,6 +273,31 @@ Button {
                 Accessible.role: Accessible.Indicator
                 Accessible.name: UserModel.desktopNotificationsAllowed ? qsTr("Current account status is online") : qsTr("Current account status is do not disturb")
             }
+
+            Rectangle {
+                id: currentAccountSyncStatusIndicatorBackground
+                visible: UserModel.currentUser && UserModel.currentUser.hasSyncStatusIssue
+                width: currentAccountSyncStatusIndicator.sourceSize.width + Style.trayFolderStatusIndicatorSizeOffset
+                height: width
+                color: "white"
+                anchors.top: currentAccountAvatar.top
+                anchors.right: currentAccountAvatar.right
+                radius: width * Style.trayFolderStatusIndicatorRadiusFactor
+            }
+
+            Image {
+                id: currentAccountSyncStatusIndicator
+                visible: UserModel.currentUser && UserModel.currentUser.hasSyncStatusIssue
+                source: UserModel.currentUser ? UserModel.currentUser.syncStatusIcon : ""
+                cache: false
+                x: currentAccountSyncStatusIndicatorBackground.x + Style.trayFolderStatusIndicatorSizeOffset / 2
+                y: currentAccountSyncStatusIndicatorBackground.y + Style.trayFolderStatusIndicatorSizeOffset / 2
+                sourceSize.width: Style.accountAvatarStateIndicatorSize
+                sourceSize.height: Style.accountAvatarStateIndicatorSize
+
+                Accessible.role: Accessible.Indicator
+                Accessible.name: qsTr("Account sync status has issues")
+            }
         }
 
         Column {

--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -61,6 +61,31 @@ AbstractButton {
                 Accessible.role: Accessible.Indicator
                 Accessible.name: model.desktopNotificationsAllowed ? qsTr("Current account status is online") : qsTr("Current account status is do not disturb")
             }
+
+            Rectangle {
+                id: accountSyncStatusIndicatorBackground
+                visible: model.hasSyncStatusIssue
+                width: accountSyncStatusIndicator.sourceSize.width + Style.trayFolderStatusIndicatorSizeOffset
+                height: width
+                color: "white"
+                anchors.top: accountAvatar.top
+                anchors.right: accountAvatar.right
+                radius: width * Style.trayFolderStatusIndicatorRadiusFactor
+            }
+
+            Image {
+                id: accountSyncStatusIndicator
+                visible: model.hasSyncStatusIssue
+                source: model.syncStatusIcon
+                cache: false
+                x: accountSyncStatusIndicatorBackground.x + Style.trayFolderStatusIndicatorSizeOffset / 2
+                y: accountSyncStatusIndicatorBackground.y + Style.trayFolderStatusIndicatorSizeOffset / 2
+                sourceSize.width: Style.accountAvatarStateIndicatorSize
+                sourceSize.height: Style.accountAvatarStateIndicatorSize
+
+                Accessible.role: Accessible.Indicator
+                Accessible.name: qsTr("Account sync status has issues")
+            }
         }
 
         ColumnLayout {

--- a/src/gui/tray/usermodel.h
+++ b/src/gui/tray/usermodel.h
@@ -61,6 +61,8 @@ class User : public QObject
     Q_PROPERTY(QUrl statusIcon READ statusIcon NOTIFY statusChanged)
     Q_PROPERTY(QString statusEmoji READ statusEmoji NOTIFY statusChanged)
     Q_PROPERTY(QString statusMessage READ statusMessage NOTIFY statusChanged)
+    Q_PROPERTY(bool hasSyncStatusIssue READ hasSyncStatusIssue NOTIFY syncStatusChanged)
+    Q_PROPERTY(QUrl syncStatusIcon READ syncStatusIcon NOTIFY syncStatusChanged)
     Q_PROPERTY(bool desktopNotificationsAllowed READ isDesktopNotificationsAllowed NOTIFY desktopNotificationsAllowedChanged)
     Q_PROPERTY(bool hasLocalFolder READ hasLocalFolder NOTIFY hasLocalFolderChanged)
     Q_PROPERTY(bool isFeaturedAppEnabled READ isFeaturedAppEnabled NOTIFY featuredAppChanged)
@@ -112,6 +114,8 @@ public:
     [[nodiscard]] QString statusMessage() const;
     [[nodiscard]] QUrl statusIcon() const;
     [[nodiscard]] QString statusEmoji() const;
+    [[nodiscard]] bool hasSyncStatusIssue() const;
+    [[nodiscard]] QUrl syncStatusIcon() const;
     void processCompletedSyncItem(const Folder *folder, const SyncFileItemPtr &item);
     [[nodiscard]] const QVariantList &groupFolders() const;
     [[nodiscard]] bool canLogout() const;
@@ -124,6 +128,7 @@ signals:
     void avatarChanged();
     void accountStateChanged();
     void statusChanged();
+    void syncStatusChanged();
     void desktopNotificationsAllowedChanged();
     void headerColorChanged();
     void headerTextColorChanged();
@@ -177,6 +182,8 @@ private:
     void parseNewGroupFolderPath(const QString &path);
     void connectPushNotifications() const;
     [[nodiscard]] bool checkPushNotificationsAreReady() const;
+    void updateSyncStatus();
+    void setSyncStatusIssue(const bool hasIssue, const QUrl &icon);
 
     bool isActivityOfCurrentAccount(const Folder *folder) const;
     [[nodiscard]] bool isUnsolvableConflict(const SyncFileItemPtr &item) const;
@@ -213,6 +220,9 @@ private:
     // used for quota warnings
     int _lastQuotaPercent = 0;
     Activity _lastQuotaActivity;
+
+    bool _hasSyncStatusIssue = false;
+    QUrl _syncStatusIcon;
 };
 
 class UserModel : public QAbstractListModel
@@ -255,6 +265,8 @@ public:
         StatusIconRole,
         StatusEmojiRole,
         StatusMessageRole,
+        HasSyncStatusIssueRole,
+        SyncStatusIconRole,
         DesktopNotificationsAllowedRole,
         AvatarRole,
         IsCurrentUserRole,


### PR DESCRIPTION
### Motivation
- When multiple user accounts are shown in the tray, it's hard to spot which account has sync problems at a glance.
- If an account has a non-ok sync status, the sync state icon should be overlaid on the avatar to improve discoverability.

### Description
- Added `Q_PROPERTY` accessors `hasSyncStatusIssue` and `syncStatusIcon` to `User` and exposed them as `hasSyncStatusIssue`/`syncStatusIcon` roles in `UserModel`.
- Implemented `updateSyncStatus` and `setSyncStatusIssue` in `User` and wired them to `FolderMan::folderListChanged`, `FolderMan::folderSyncStateChange`, and `AccountState::stateChanged` to compute status via `FolderMan::trayOverallStatus` and `Theme::instance()->syncStatus*` icons.
- Updated `UserLine.qml` and `CurrentAccountHeaderButton.qml` to render an overlay indicator on top of the avatar using the new model roles, and emit `syncStatusChanged` to trigger view updates.
- Hooked up model change notifications so the QML list and header update when the per-account sync status changes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69576d228ee0833387cb3de517c058de)