### PR TITLE
feat: move settings navigation to left sidebar

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -37,7 +37,7 @@
 namespace {
 const QString TOOLBAR_CSS()
 {
-    return QStringLiteral("QToolBar { background: %1; margin: 0; padding: 0; border: none; border-bottom: 1px solid %2; spacing: 0; } "
+    return QStringLiteral("QToolBar { background: %1; margin: 0; padding: 0; border: none; border-right: 1px solid %2; spacing: 0; } "
                           "QToolBar QToolButton { background: %1; border: none; border-bottom: 1px solid %2; margin: 0; padding: 5px; } "
                           "QToolBar QToolBarExtension { padding:0; } "
                           "QToolBar QToolButton:checked { background: %3; color: %4; }");
@@ -81,8 +81,12 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     _ui->setupUi(this);
     _toolBar = new QToolBar;
     _toolBar->setIconSize(QSize(32, 32));
-    _toolBar->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    layout()->setMenuBar(_toolBar);
+    _toolBar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+    _toolBar->setOrientation(Qt::Vertical);
+    _toolBar->setMovable(false);
+    _ui->mainLayout->insertWidget(0, _toolBar);
+    _ui->mainLayout->setStretch(0, 0);
+    _ui->mainLayout->setStretch(1, 1);
 
     // People perceive this as a Window, so also make Ctrl+W work
     auto *closeWindowAction = new QAction(this);
@@ -105,15 +109,10 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     _actionGroup->setExclusive(true);
     connect(_actionGroup, &QActionGroup::triggered, this, &SettingsDialog::slotSwitchPage);
 
-    // Adds space between users + activities and general + network actions
-    auto *spacer = new QWidget();
-    spacer->setMinimumWidth(10);
-    spacer->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Minimum);
-    _toolBar->addWidget(spacer);
-
     QAction *generalAction = createColorAwareAction(QLatin1String(":/client/theme/settings.svg"), tr("General"));
     _actionGroup->addAction(generalAction);
     _toolBar->addAction(generalAction);
+    _accountsSeparator = _toolBar->addSeparator();
     auto *generalSettings = new GeneralSettings;
     _ui->stack->addWidget(generalSettings);
 
@@ -234,7 +233,7 @@ void SettingsDialog::accountAdded(AccountState *s)
         accountAction->setIconText(shortDisplayNameForSettings(s->account().data(), static_cast<int>(height * buttonSizeRatio)));
     }
 
-    _toolBar->insertAction(_toolBar->actions().at(0), accountAction);
+    _toolBar->addAction(accountAction);
     auto accountSettings = new AccountSettings(s, this);
     QString objectName = QLatin1String("accountSettings_");
     objectName += s->account()->displayName();

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -83,6 +83,7 @@ private:
     QHash<Account *, QAction *> _actionForAccount;
 
     QToolBar *_toolBar;
+    QAction *_accountsSeparator = nullptr;
 
     ownCloudGui *_gui;
 };

--- a/src/gui/settingsdialog.ui
+++ b/src/gui/settingsdialog.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Settings</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QHBoxLayout" name="mainLayout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -29,7 +29,7 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <item row="0" column="0">
+   <item>
     <widget class="QStackedWidget" name="stack">
      <property name="lineWidth">
       <number>0</number>


### PR DESCRIPTION
### Motivation
- Align the settings dialog with modern macOS/Windows left-to-right navigation by moving the navigation to a left vertical sidebar.
- Present `General` first, then a separator, and list accounts below to improve hierarchy and discoverability.
- Ensure the stacked settings area continues to fill the remaining space beside the navigation.

### Description
- Replace the top toolbar layout with a left-aligned vertical toolbar by changing `src/gui/settingsdialog.ui` to use a `QHBoxLayout` named `mainLayout` and inserting the toolbar into it.
- Configure the toolbar as vertical and non-movable and change the tool button style to `Qt::ToolButtonTextBesideIcon`, update the toolbar CSS to use a right border, and set layout stretches in `src/gui/settingsdialog.cpp`.
- Add an accounts separator via `_accountsSeparator = _toolBar->addSeparator()` and switch account actions to be added with `addAction(...)` instead of inserting at position 0.
- Add the `_accountsSeparator` member to `src/gui/settingsdialog.h` to hold the separator action.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69576f6865f08333b2aafb83fa20fb24)