### PR TITLE
fix: tighten tray spacing and blue account selection highlight

### DIFF
--- a/src/gui/tray/CurrentAccountHeaderButton.qml
+++ b/src/gui/tray/CurrentAccountHeaderButton.qml
@@ -71,8 +71,21 @@ Button {
             id: userLineInstantiator
             model: UserModel
             delegate: MenuItem {
+                id: userLineMenuItem
                 implicitHeight: instantiatedUserLine.height
-                UserLine {
+                padding: 0
+                leftPadding: 0
+                rightPadding: 0
+                topPadding: 0
+                bottomPadding: 0
+                indicator: null
+
+                background: Rectangle {
+                    color: (userLineMenuItem.highlighted || userLineMenuItem.down) ? Style.ncBlue : "transparent"
+                    radius: 0
+                }
+
+                contentItem: UserLine {
                     id: instantiatedUserLine
                     width: Math.min(accountMenu.widestMenuItemWidth, accountMenu.maximumWidthAllowed)
 

--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -134,7 +134,7 @@ ApplicationWindow {
             radius: Systray.useNormalWindow ? 0.0 : Style.trayWindowRadius
             border.width: Style.trayWindowBorderWidth
             border.color: palette.dark
-            color: Style.colorWithoutTransparency(palette.base)
+            color: Style.colorWithoutTransparency(palette.dark)
         }
 
         property int userIndex: 0
@@ -180,7 +180,7 @@ ApplicationWindow {
             radius: Systray.useNormalWindow ? 0.0 : Style.trayWindowRadius
             border.width: Style.trayWindowBorderWidth
             border.color: palette.dark
-            color: Style.colorWithoutTransparency(palette.base)
+            color: Style.colorWithoutTransparency(palette.dark)
         }
 
         property var folderAccountState: ({})
@@ -239,7 +239,7 @@ ApplicationWindow {
         clip: true
 
         radius: Systray.useNormalWindow ? 0.0 : Style.trayWindowRadius
-        color: Style.colorWithoutTransparency(palette.base)
+        color: Style.colorWithoutTransparency(palette.dark)
 
         Accessible.role: Accessible.Grouping
         Accessible.name: qsTr("Main content")

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -47,7 +47,7 @@ QtObject {
     property int halfTrayWindowRadius: 5
     property int trayWindowBorderWidth: variableSize(1)
     property int trayWindowHeaderHeight: variableSize(50)
-    property int trayHorizontalMargin: 10
+    property int trayHorizontalMargin: 8
     property int trayModalWidth: 380
     property int trayModalHeight: 490
     property int trayListItemIconSize: accountAvatarSize


### PR DESCRIPTION
### Motivation
- Reduce excessive margins and prevent account row content from shifting when selected to improve tray UI density and stability.
- Make the active account indication visually distinct with a blue background to match design intent.
- Increase contrast for rounded content panels so they are visible against the window background.

### Description
- Reduced the global tray horizontal margin from `10` to `8` by updating `theme/Style/Style.qml` (`trayHorizontalMargin`).
- Removed padding and the default `indicator` for account menu rows and wrapped each delegate in a `MenuItem` with `background` set to `Style.ncBlue` when highlighted or pressed, and `contentItem` set to the existing `UserLine` to avoid content jumping, in `src/gui/tray/CurrentAccountHeaderButton.qml`.
- Darkened the tray main content and drawer panel backgrounds by switching their color from `palette.base` to `palette.dark` (via `Style.colorWithoutTransparency`) in `src/gui/tray/MainWindow.qml` so rounded panels are visible.

### Testing
- No automated tests were executed for this UI-only change.
- Changes were kept minimal and localized to QML styling and layout values to limit risk to logic paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696737ba999c83338bc4fb25acf0d0f6)