### PR TITLE
fix: align account tab pane background

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -179,11 +179,9 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     const auto delegate = new FolderStatusDelegate;
     delegate->setParent(this);
 
-    #if defined(Q_OS_MACOS)
     _ui->tabWidget->setStyleSheet(QStringLiteral(
-        "QTabWidget { background: palette(window); }"
-        "QTabWidget::pane { background: palette(window); }"));
-    #endif
+        "QTabWidget { background: transparent; }"
+        "QTabWidget::pane { background: transparent; border: none; }"));
     
     // Connect styleChanged events to our widgets, so they can adapt (Dark-/Light-Mode switching)
     connect(this, &AccountSettings::styleChanged, delegate, &FolderStatusDelegate::slotStyleChanged);


### PR DESCRIPTION
### Motivation
- Remove the mismatched white pane/line under the account tabs so the tab content visually matches the surrounding `#accountTabsPanel` background.

### Description
- Update `src/gui/accountsettings.cpp` to set the `_ui->tabWidget` stylesheet to `QTabWidget { background: transparent; }` and `QTabWidget::pane { background: transparent; border: none; }` so the tab widget inherits the panel background.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967c1ca1a1c8333b97091ddf6662ea5)