### PR TITLE
fix: restore settings dialog background separation

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -33,6 +33,8 @@
 #include <QPainterPath>
 #include <QQuickView>
 #include <QActionGroup>
+#include <QScopedValueRollback>
+#include <QTimer>
 
 namespace {
 const QString TOOLBAR_CSS()
@@ -170,14 +172,6 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
 
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint & Qt::Window);
     cfg.restoreGeometry(this);
-    setStyleSheet(QStringLiteral(
-        "#Settings { background: #f2f2f2; }"
-        "#settings_shell { background: transparent; border-radius: 0; }"
-        "#settings_navigation { background: #e7e7e7; border-radius: 12px; }"
-        "#generalGroupBox, #advancedGroupBox, #aboutAndUpdatesGroupBox,"
-        "#accountStatusPanel, #accountStoragePanel, #accountTabsPanel {"
-        " background: #e7e7e7; border-radius: 10px; border: none; margin: 6px; padding: 12px; }"
-        ));
 }
 
 SettingsDialog::~SettingsDialog()
@@ -211,10 +205,7 @@ void SettingsDialog::changeEvent(QEvent *e)
     case QEvent::StyleChange:
     case QEvent::PaletteChange:
     case QEvent::ThemeChange:
-        customizeStyle();
-
-        // Notify the other widgets (Dark-/Light-Mode switching)
-        emit styleChanged();
+        requestStyleUpdate();
         break;
     case QEvent::ActivationChange:
         if(isActiveWindow())
@@ -354,9 +345,41 @@ void SettingsDialog::accountRemoved(AccountState *s)
     }
 }
 
+void SettingsDialog::requestStyleUpdate()
+{
+    if (_styleUpdatePending) {
+        return;
+    }
+
+    _styleUpdatePending = true;
+    QTimer::singleShot(0, this, [this]() {
+        _styleUpdatePending = false;
+        customizeStyle();
+
+        // Notify the other widgets (Dark-/Light-Mode switching)
+        emit styleChanged();
+    });
+}
+
 void SettingsDialog::customizeStyle()
 {
+    if (_updatingStyle) {
+        return;
+    }
+
+    const QScopedValueRollback<bool> updatingStyle(_updatingStyle, true);
     _toolBar->setStyleSheet(TOOLBAR_CSS());
+
+    const auto windowColor = palette().base().color();
+    const auto panelColor = palette().window().color();
+    setStyleSheet(QStringLiteral(
+        "#Settings { background: %1; }"
+        "#settings_shell { background: transparent; border-radius: 0; }"
+        "#settings_navigation { background: %2; border-radius: 12px; }"
+        "#generalGroupBox, #advancedGroupBox, #aboutAndUpdatesGroupBox,"
+        "#accountStatusPanel, #accountStoragePanel, #accountTabsPanel {"
+        " background: %2; border-radius: 10px; border: none; margin: 6px; padding: 12px; }"
+        ).arg(windowColor.name(), panelColor.name()));
 
     const auto &allActions = _actionGroup->actions();
     for (const auto a : allActions) {

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -68,6 +68,7 @@ private slots:
 
 private:
     void customizeStyle();
+    void requestStyleUpdate();
 
     QAction *createColorAwareAction(const QString &iconName, const QString &fileName);
     QAction *createActionWithIcon(const QIcon &icon, const QString &text, const QString &iconPath = QString());
@@ -85,6 +86,8 @@ private:
     QToolBar *_toolBar;
 
     ownCloudGui *_gui;
+    bool _styleUpdatePending = false;
+    bool _updatingStyle = false;
 };
 }
 


### PR DESCRIPTION
### Motivation
- Restore visual separation between the dialog shell and content panels so the window background is brighter while panels keep the existing color in both light and dark modes.
- Keep style-update handling safe by deferring and coalescing palette/theme/style change events to avoid re-entrancy issues.

### Description
- Use `palette().base()` as the dialog background (`windowColor`) and keep `palette().window()` for panel backgrounds (`panelColor`) in the stylesheet so the shell remains visually distinct from panels.
- Replace hardcoded colors with `windowColor.name()` and `panelColor.name()` in `setStyleSheet()` and compute them in `customizeStyle()`.
- Add `requestStyleUpdate()` and bool members ` _styleUpdatePending` and `_updatingStyle` to coalesce updates, and call `requestStyleUpdate()` from `changeEvent()` for `QEvent::StyleChange`, `QEvent::PaletteChange`, and `QEvent::ThemeChange`.
- Defer actual style application using `QTimer::singleShot(0, ...)` and protect `customizeStyle()` from re-entrancy with an early return and `QScopedValueRollback<bool>`; also added necessary includes and header declarations for the new members and function.

### Testing
- No automated tests were executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69683eab3264833386327bb611e14f8f)