### PR TITLE
fix: move storage usage into account status and align E2E buttons

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -52,6 +52,7 @@
 #include <QVariant>
 #include <QJsonDocument>
 #include <QToolTip>
+#include <QToolButton>
 
 #ifdef BUILD_FILE_PROVIDER_MODULE
 #include "macOS/fileprovider.h"
@@ -1681,6 +1682,17 @@ void AccountSettings::customizeStyle()
 
     const auto color = palette().highlight().color();
     _ui->quotaProgressBar->setStyleSheet(QString::fromLatin1(progressBarStyleC).arg(color.name()));
+    applyEncryptionMessageButtonStyle();
+}
+
+void AccountSettings::applyEncryptionMessageButtonStyle()
+{
+    const auto buttons = _ui->encryptionMessage->findChildren<QToolButton *>();
+    for (auto *button : buttons) {
+        button->setAutoRaise(false);
+        button->setToolButtonStyle(Qt::ToolButtonTextOnly);
+        button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    }
 }
 
 void AccountSettings::setupE2eEncryption()
@@ -1746,6 +1758,7 @@ QAction *AccountSettings::addActionToEncryptionMessage(const QString &actionTitl
         action->setProperty(e2eUiActionIdKey, actionId);
     }
     _ui->encryptionMessage->addAction(action);
+    applyEncryptionMessageButtonStyle();
     return action;
 }
 

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -121,6 +121,7 @@ private slots:
     void showConnectionLabel(const QString &message, QStringList errors = QStringList());
     void openIgnoredFilesDialog(const QString & absFolderPath);
     void customizeStyle();
+    void applyEncryptionMessageButtonStyle();
 
     void setupE2eEncryption();
     void forgetE2eEncryption();

--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -74,30 +74,6 @@
        </widget>
       </item>
       <item>
-       <widget class="KMessageWidget" name="encryptionMessage" native="true"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QFrame" name="accountStoragePanel">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <layout class="QVBoxLayout" name="accountStorageLayout">
-      <property name="leftMargin">
-       <number>12</number>
-      </property>
-      <property name="topMargin">
-       <number>12</number>
-      </property>
-      <property name="rightMargin">
-       <number>12</number>
-      </property>
-      <property name="bottomMargin">
-       <number>12</number>
-      </property>
-      <item>
        <layout class="QHBoxLayout" name="storageGroupBox">
         <item>
          <widget class="QLabel" name="quotaInfoLabel">
@@ -151,10 +127,13 @@
         </item>
        </layout>
       </item>
+      <item>
+       <widget class="KMessageWidget" name="encryptionMessage" native="true"/>
+      </item>
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QFrame" name="accountTabsPanel">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -377,7 +377,7 @@ void SettingsDialog::customizeStyle()
         "#settings_shell { background: transparent; border-radius: 0; }"
         "#settings_navigation { background: %2; border-radius: 12px; }"
         "#generalGroupBox, #advancedGroupBox, #aboutAndUpdatesGroupBox,"
-        "#accountStatusPanel, #accountStoragePanel, #accountTabsPanel {"
+        "#accountStatusPanel, #accountTabsPanel {"
         " background: %2; border-radius: 10px; border: none; margin: 6px; padding: 12px; }"
         ).arg(windowColor.name(), panelColor.name()));
 


### PR DESCRIPTION
### Motivation
- The storage usage was shown in a separate panel from the account connection status which made the layout inconsistent. 
- End-to-end encryption (E2E) actions used a different button appearance than other settings buttons which looked out of place.

### Description
- Moved the storage usage widget into the account status panel by updating `src/gui/accountsettings.ui` so storage appears below the connection label and above the E2E message. 
- Removed the standalone storage panel selector from the global settings stylesheet by updating `src/gui/settingsdialog.cpp` to no longer reference `#accountStoragePanel`.
- Introduced `applyEncryptionMessageButtonStyle()` (declared in `src/gui/accountsettings.h` and implemented in `src/gui/accountsettings.cpp`) to normalize E2E action buttons by styling `QToolButton` children with `setAutoRaise(false)`, `setToolButtonStyle(Qt::ToolButtonTextOnly)`, and a fixed `QSizePolicy`, and invoked this styling from `customizeStyle()` and after adding encryption actions. 
- Added the required include for `QToolButton` and applied the styling immediately when actions are added so E2E buttons match other settings buttons.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696904ff8aa8833382a490d07760d023)