### PR TITLE
fix: separate settings panel colors

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -370,15 +370,16 @@ void SettingsDialog::customizeStyle()
     const QScopedValueRollback<bool> updatingStyle(_updatingStyle, true);
     _toolBar->setStyleSheet(TOOLBAR_CSS());
 
-    const auto windowColor = palette().base().color();
-    const auto panelColor = palette().window().color();
+    const auto windowColor = palette().window().color();
+    const auto isDarkWindow = windowColor.lightness() < 128;
+    const auto panelColor = isDarkWindow ? windowColor.lighter(115) : windowColor.darker(105);
     setStyleSheet(QStringLiteral(
         "#Settings { background: %1; }"
         "#settings_shell { background: transparent; border-radius: 0; }"
-        "#settings_navigation { background: %1; border-radius: 12px; }"
+        "#settings_navigation { background: %2; border-radius: 12px; }"
         "#generalGroupBox, #advancedGroupBox, #aboutAndUpdatesGroupBox,"
         "#accountStatusPanel, #accountTabsPanel {"
-        " background: %1; border-radius: 10px; border: none; margin: margin: 6px 0px 0px 0px; padding: 6px; }"
+        " background: %2; border-radius: 10px; border: none; margin: margin: 6px 0px 0px 0px; padding: 6px; }"
         ).arg(windowColor.name(), panelColor.name()));
 
     const auto &allActions = _actionGroup->actions();


### PR DESCRIPTION
### Motivation
- Panels in the settings dialog became indistinguishable from the window background after introducing bright/dark mode, so the UI needs a mode-compatible visual separation between window and panel colors.

### Description
- In `src/gui/settingsdialog.cpp` derive the panel color from `palette().window().color()` by checking `windowColor.lightness() < 128` and using `windowColor.lighter(115)` for dark windows or `windowColor.darker(105)` for light windows, and update the stylesheet placeholders so the window uses the first arg and panels use the second arg.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969b2ee564c83339b398fa7131693b4)