### PR TITLE
fix: reduce settings nav active indicator padding

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -40,9 +40,9 @@ namespace {
 const QString TOOLBAR_CSS()
 {
     return QStringLiteral("QToolBar { background: transparent; margin: 0; padding: 0; border: none; spacing: 0; } "
-                          "QToolBar QToolButton { background: transparent; border: none; margin: 0; padding: 8px 12px; font-size: 14px; } "
+                          "QToolBar QToolButton { background: transparent; border: none; margin: 0; padding: 6px 12px; font-size: 14px; } "
                           "QToolBar QToolBarExtension { padding:0; } "
-                          "QToolBar QToolButton:checked { background: #0a84ff; color: #ffffff; border-radius: 8px; margin: 0; }");
+                          "QToolBar QToolButton:checked { background: #0a84ff; color: #ffffff; border-radius: 8px; margin: 2px 8px; padding: 4px 10px; }");
 }
 
 const float buttonSizeRatio = 1.618f; // golden ratio


### PR DESCRIPTION
### Motivation
- Make the blue active indicator for selected items in the settings navigation less tall and inset from the navigation panel edges so it appears visually smaller and more balanced.

### Description
- Adjusted the toolbar stylesheet in `src/gui/settingsdialog.cpp` by changing `QToolBar QToolButton` padding from `8px 12px` to `6px 12px` and by adding smaller insets for the `QToolButton:checked` state with `margin: 2px 8px; padding: 4px 10px;`.

### Testing
- No automated tests were run for this UI style change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a08d446488333ad6e9944260758ec)