### PR TITLE
fix: add independent vertical scrolling to Settings dialog

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -34,6 +34,7 @@
 #include <QQuickView>
 #include <QActionGroup>
 #include <QScopedValueRollback>
+#include <QScrollArea>
 #include <QTimer>
 
 namespace {
@@ -100,8 +101,20 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     navigationLayout->setContentsMargins(0, 0, 0, 0);
     navigationLayout->setSpacing(0);
     navigationLayout->addWidget(_toolBar);
-    shellLayout->addWidget(navigationContainer);
-    shellLayout->addWidget(_ui->stack);
+    auto *navigationScroll = new QScrollArea(shellContainer);
+    navigationScroll->setWidgetResizable(true);
+    navigationScroll->setFrameShape(QFrame::NoFrame);
+    navigationScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    navigationScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    navigationScroll->setWidget(navigationContainer);
+    auto *contentScroll = new QScrollArea(shellContainer);
+    contentScroll->setWidgetResizable(true);
+    contentScroll->setFrameShape(QFrame::NoFrame);
+    contentScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    contentScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    contentScroll->setWidget(_ui->stack);
+    shellLayout->addWidget(navigationScroll);
+    shellLayout->addWidget(contentScroll);
     shellLayout->setStretch(0, 0);
     shellLayout->setStretch(1, 1);
     _ui->mainLayout->removeWidget(_ui->stack);


### PR DESCRIPTION
### Motivation
- The Settings dialog could grow very tall when pages contained lots of content, so the UI should remain compact and allow overflow to be scrollable with navigation and content scrolling independently.

### Description
- Wrap the navigation widget and the main `QStackedWidget` in separate `QScrollArea`s in `src/gui/settingsdialog.cpp` and configure them with `setWidgetResizable(true)`, `QFrame::NoFrame`, horizontal scrolling disabled and vertical scrolling set to `ScrollBarAsNeeded`.
- Add the new scroll areas to the shell layout so the dialog height stays bounded while each pane can scroll independently.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a090d6d64833382d7e917f6e2773a)