### PR TITLE
fix: align settings panels

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -392,7 +392,7 @@ void SettingsDialog::customizeStyle()
         "#settings_navigation { background: %2; border-radius: 12px; }"
         "#generalGroupBox, #advancedGroupBox, #aboutAndUpdatesGroupBox,"
         "#accountStatusPanel, #accountTabsPanel {"
-        " background: %2; border-radius: 10px; border: none; margin: 6px 0px 0px 0px; padding: 6px; }"
+        " background: %2; border-radius: 10px; border: none; margin: 0px; padding: 6px; }"
         ).arg(windowColor.name(), panelColor.name()));
 
     const auto &allActions = _actionGroup->actions();


### PR DESCRIPTION
### Motivation
- Align the account status and account tabs panels with the navigation panel by removing an extra top margin that caused visual misalignment.

### Description
- Update `src/gui/settingsdialog.cpp` to change the stylesheet rule for `#accountStatusPanel, #accountTabsPanel` from `margin: 6px 0px 0px 0px` to `margin: 0px` so the panels line up with the navigation panel.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b4ed82f688333a3120828ab127d15)