### PR TITLE
fix: refine settings layout spacing

### DIFF
--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -14,6 +14,18 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="0" column="0">
     <widget class="QFrame" name="accountStatusPanel">
      <property name="frameShape">
@@ -75,6 +87,22 @@
       </item>
       <item>
        <layout class="QHBoxLayout" name="storageGroupBox">
+        <item>
+         <spacer name="storageStatusSpacer">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Policy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>24</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
         <item>
          <widget class="QLabel" name="quotaInfoLabel">
           <property name="sizePolicy">

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -14,40 +14,49 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <property name="spacing">
+    <number>12</number>
+   </property>
    <item row="0" column="0">
-    <widget class="QLabel" name="generalGroupBoxTitle">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>General Settings</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QGroupBox" name="generalGroupBox">
      <property name="title">
       <string/>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="generalGroupBoxTitle">
+        <property name="text">
+         <string>General settings</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
        <widget class="QCheckBox" name="autostartCheckBox">
         <property name="text">
          <string>&amp;Launch on System Startup</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QCheckBox" name="callNotificationsCheckBox">
         <property name="text">
          <string>Show Call Notifications</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QCheckBox" name="monoIconsCheckBox">
         <property name="toolTip">
          <string>For System Tray</string>
@@ -57,21 +66,21 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QCheckBox" name="chatNotificationsCheckBox">
         <property name="text">
          <string>Show Chat Notifications</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QCheckBox" name="serverNotificationsCheckBox">
         <property name="text">
          <string>Show Server &amp;Notifications</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QCheckBox" name="quotaWarningNotificationsCheckBox">
         <property name="text">
          <string>Show &amp;Quota Warning Notifications</string>
@@ -81,25 +90,19 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="advancedGroupBoxTitle">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Advanced</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
+   <item row="1" column="0">
     <widget class="QGroupBox" name="advancedGroupBox">
      <property name="title">
       <string/>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="advancedGroupBoxTitle">
+        <property name="text">
+         <string>Advanced</string>
+        </property>
+       </widget>
+      </item>
       <item>
        <layout class="QVBoxLayout" name="verticalLayout_4">
         <property name="spacing">
@@ -330,25 +333,19 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="aboutAndUpdatesGroupBoxTitle">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Info</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
+   <item row="2" column="0">
     <widget class="QGroupBox" name="aboutAndUpdatesGroupBox">
      <property name="title">
       <string/>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QLabel" name="aboutAndUpdatesGroupBoxTitle">
+        <property name="text">
+         <string>Info</string>
+        </property>
+       </widget>
+      </item>
       <property name="bottomMargin">
        <number>10</number>
       </property>

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -94,7 +94,7 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     auto *shellContainer = new QWidget(this);
     shellContainer->setObjectName(QLatin1String("settings_shell"));
     auto *shellLayout = new QHBoxLayout(shellContainer);
-    shellLayout->setContentsMargins(6, 6, 6, 6);
+    shellLayout->setContentsMargins(0, 0, 0, 0);
     shellLayout->setSpacing(6);
     auto *navigationContainer = new QWidget(this);
     navigationContainer->setObjectName(QLatin1String("settings_navigation"));
@@ -114,6 +114,7 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     contentScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     contentScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     auto *contentContainer = new QWidget(contentScroll);
+    contentContainer->setObjectName(QLatin1String("settings_content"));
     auto *contentLayout = new QVBoxLayout(contentContainer);
     contentLayout->setContentsMargins(0, 0, 0, 0);
     contentLayout->setSpacing(0);
@@ -399,6 +400,7 @@ void SettingsDialog::customizeStyle()
         "#Settings { background: %1; }"
         "#settings_shell { background: transparent; border-radius: 0; }"
         "#settings_navigation { background: %2; border-radius: 12px; }"
+        "#settings_content { background: transparent; }"
         "#generalGroupBox, #advancedGroupBox, #aboutAndUpdatesGroupBox,"
         "#accountStatusPanel, #accountTabsPanel {"
         " background: %2; border-radius: 10px; border: none; margin: 0px; padding: 6px; }"


### PR DESCRIPTION
### Motivation
- Prevent small vertical jumps when switching navigation items by fixing unexpected margins/paddings around settings content.
- Make section headings like `General settings`, `Advanced` and `Info` sit inside their panels and use regular weight so they visually align with their group boxes.
- Remove the darker wrapper background and extra paddings around the stacked panels and align the account connection status with the storage usage controls.

### Description
- Moved the `General settings`, `Advanced` and `Info` heading labels into their respective `QGroupBox` widgets in `src/gui/generalsettings.ui` and removed the bold font usage so the headings are non-bold and part of the panels.
- Removed outer paddings by setting the main grid layouts' margins and spacing in `src/gui/generalsettings.ui` and `src/gui/accountsettings.ui` to remove unexpected offsets and added a small consistent spacing between panels.
- Aligned account connection and storage rows by inserting a fixed spacer (`storageStatusSpacer`) before the quota label in `src/gui/accountsettings.ui` so the `connectLabel` and `quotaInfoLabel` line up.
- Eliminated the darker background/padding around the content wrapper by clearing `shellLayout` margins, adding `settings_content` object name to the content container, and making `#settings_content` transparent in `src/gui/settingsdialog.cpp` so the stacked widget area is visually flush.

### Testing
- No automated tests were run on these UI/layout changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696badcccb848333b930d2eb8e8cf0df)