### PR TITLE
fix: remove account status layout margins

### DIFF
--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -32,18 +32,18 @@
       <enum>QFrame::NoFrame</enum>
      </property>
      <layout class="QVBoxLayout" name="accountStatusLayout">
-      <property name="leftMargin">
-       <number>12</number>
-      </property>
-      <property name="topMargin">
-       <number>12</number>
-      </property>
-      <property name="rightMargin">
-       <number>12</number>
-      </property>
-      <property name="bottomMargin">
-       <number>12</number>
-      </property>
+     <property name="leftMargin">
+       <number>0</number>
+     </property>
+     <property name="topMargin">
+       <number>0</number>
+     </property>
+     <property name="rightMargin">
+       <number>0</number>
+     </property>
+     <property name="bottomMargin">
+       <number>0</number>
+     </property>
       <item>
        <widget class="QWidget" name="accountStatus" native="true">
         <layout class="QGridLayout" name="gridLayout_2">


### PR DESCRIPTION
### Motivation
- Reduce excessive whitespace around the account status area in the account settings UI by removing the layout margins.

### Description
- Set the `leftMargin`, `topMargin`, `rightMargin` and `bottomMargin` of `accountStatusLayout` to `0` in `src/gui/accountsettings.ui` (previously `12`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c6bf608188333b263d96465ea3ad4)