### PR TITLE
fix: align account settings tab backgrounds

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -45,6 +45,7 @@
 #include <QListWidgetItem>
 #include <QMessageBox>
 #include <QAction>
+#include <QSizePolicy>
 #include <QVBoxLayout>
 #include <QTreeView>
 #include <QKeySequence>
@@ -186,10 +187,15 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
 
     _ui->tabWidget->setStyleSheet(QStringLiteral(
         "QTabWidget { background: transparent; }"
-        "QTabWidget::pane { background: transparent; border: none; }"
-        "QWidget#standardSyncTab { background: transparent; }"));
-    _ui->standardSyncTab->setAutoFillBackground(false);
-    _ui->standardSyncTab->setAttribute(Qt::WA_StyledBackground, false);
+        "QTabWidget::pane { background: palette(alternate-base); border: none; }"
+        "QWidget#standardSyncTab, QWidget#fileProviderTab, QWidget#connectionSettingsTab {"
+        " background: palette(alternate-base); }"));
+    _ui->standardSyncTab->setAutoFillBackground(true);
+    _ui->standardSyncTab->setAttribute(Qt::WA_StyledBackground, true);
+    _ui->fileProviderTab->setAutoFillBackground(true);
+    _ui->fileProviderTab->setAttribute(Qt::WA_StyledBackground, true);
+    _ui->connectionSettingsTab->setAutoFillBackground(true);
+    _ui->connectionSettingsTab->setAttribute(Qt::WA_StyledBackground, true);
 
     // Connect styleChanged events to our widgets, so they can adapt (Dark-/Light-Mode switching)
     connect(this, &AccountSettings::styleChanged, delegate, &FolderStatusDelegate::slotStyleChanged);
@@ -209,7 +215,9 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     const auto fpSettingsWidget = fpSettingsController->settingsViewWidget(fpAccountUserIdAtHost, fileProviderTab,
                                                                            QQuickWidget::SizeViewToRootObject);
     fpSettingsLayout->setContentsMargins(0, 0, 0, 0);
-    fpSettingsLayout->addWidget(fpSettingsWidget);
+    fpSettingsLayout->setSpacing(0);
+    fpSettingsWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    fpSettingsLayout->addWidget(fpSettingsWidget, 1);
     fileProviderTab->setLayout(fpSettingsLayout);
 #else
     const auto tabWidget = _ui->tabWidget;
@@ -224,7 +232,8 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     const auto connectionSettingsLayout = new QVBoxLayout(connectionSettingsTab);
     const auto networkSettings = new NetworkSettings(_accountState->account(), connectionSettingsTab);
     connectionSettingsLayout->setContentsMargins(0, 0, 0, 0);
-    connectionSettingsLayout->addWidget(networkSettings);
+    connectionSettingsLayout->setSpacing(0);
+    connectionSettingsLayout->addWidget(networkSettings, 1);
     connectionSettingsTab->setLayout(connectionSettingsLayout);
 
     const auto mouseCursorChanger = new MouseCursorChanger(this);


### PR DESCRIPTION
### Motivation
- `QTabWidget` pane and tab pages had inconsistent backgrounds causing visual mismatch in the account settings dialog.
- File Provider and Connection Settings content did not reliably stretch to fill the tab area, leading to unused space or clipped QML content.
- A `QSizePolicy` include was required to set the expanding policy for the embedded QML widget.

### Description
- Updated the `QTabWidget` stylesheet to use `palette(alternate-base)` for the pane and for `#standardSyncTab`, `#fileProviderTab`, and `#connectionSettingsTab`.
- Enabled `setAutoFillBackground(true)` and set `Qt::WA_StyledBackground` on the three tab pages to ensure the styled backgrounds are applied.
- Set `QVBoxLayout::setSpacing(0)`, applied `QSizePolicy::Expanding` to the file provider QML widget, and added the File Provider and Network Settings widgets with stretch `1` so they fill the available space.
- Added `#include <QSizePolicy>` to support the size policy usage.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ddc0fa40c83339fb16da85baffaa2)