### PR TITLE
fix: align folder sync background with alternate base

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -201,6 +201,9 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     connect(this, &AccountSettings::styleChanged, delegate, &FolderStatusDelegate::slotStyleChanged);
 
     _ui->_folderList->header()->hide();
+    _ui->_folderList->setAutoFillBackground(true);
+    _ui->_folderList->setAttribute(Qt::WA_StyledBackground, true);
+    _ui->_folderList->setStyleSheet(QStringLiteral("QTreeView { background: palette(alternate-base); }"));
     _ui->_folderList->setItemDelegate(delegate);
     _ui->_folderList->setModel(_model);
     _ui->_folderList->setMinimumWidth(300);


### PR DESCRIPTION
### Motivation
- The folder sync list (`_folderList`) was showing the default base background instead of matching the tab pane's `palette(alternate-base)`.

### Description
- Set `setAutoFillBackground(true)` and `setAttribute(Qt::WA_StyledBackground, true)` on `_ui->_folderList` and applied `setStyleSheet(QStringLiteral("QTreeView { background: palette(alternate-base); }"))` to make the list view use the tab pane palette.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696edefa5a8083339d5adad5b12419b1)