### PR TITLE
fix: align file provider panel styling

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -188,12 +188,12 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     _ui->tabWidget->setStyleSheet(QStringLiteral(
         "QTabWidget { background: transparent; }"
         "QTabWidget::pane { background: palette(alternate-base); border: none; }"
-        "QWidget#standardSyncTab, QWidget#fileProviderTab, QWidget#connectionSettingsTab {"
+        "QWidget#standardSyncTab, QWidget#connectionSettingsTab, QWidget#fileProviderPanelContents {"
         " background: palette(alternate-base); }"));
     _ui->standardSyncTab->setAutoFillBackground(true);
     _ui->standardSyncTab->setAttribute(Qt::WA_StyledBackground, true);
-    _ui->fileProviderTab->setAutoFillBackground(true);
-    _ui->fileProviderTab->setAttribute(Qt::WA_StyledBackground, true);
+    _ui->fileProviderPanelContents->setAutoFillBackground(true);
+    _ui->fileProviderPanelContents->setAttribute(Qt::WA_StyledBackground, true);
     _ui->connectionSettingsTab->setAutoFillBackground(true);
     _ui->connectionSettingsTab->setAttribute(Qt::WA_StyledBackground, true);
     
@@ -208,24 +208,19 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     new ToolTipUpdater(_ui->_folderList);
 
 #if defined(BUILD_FILE_PROVIDER_MODULE)
-    const auto fileProviderTab = _ui->fileProviderTab;
-    const auto fpSettingsLayout = new QVBoxLayout(fileProviderTab);
+    const auto fileProviderPanelContents = _ui->fileProviderPanelContents;
+    const auto fpSettingsLayout = new QVBoxLayout(fileProviderPanelContents);
     const auto fpAccountUserIdAtHost = _accountState->account()->userIdAtHostWithPort();
     const auto fpSettingsController = Mac::FileProviderSettingsController::instance();
-    const auto fpSettingsWidget = fpSettingsController->settingsViewWidget(fpAccountUserIdAtHost, fileProviderTab,
-                                                                           QQuickWidget::SizeViewToRootObject);
+    const auto fpSettingsWidget = fpSettingsController->settingsViewWidget(fpAccountUserIdAtHost, fileProviderPanelContents,
+                                                                           QQuickWidget::SizeRootObjectToView);
     fpSettingsLayout->setContentsMargins(0, 0, 0, 0);
     fpSettingsLayout->setSpacing(0);
     fpSettingsWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     fpSettingsLayout->addWidget(fpSettingsWidget, 1);
-    fileProviderTab->setLayout(fpSettingsLayout);
+    fileProviderPanelContents->setLayout(fpSettingsLayout);
 #else
-    const auto tabWidget = _ui->tabWidget;
-    const auto fileProviderTab = _ui->fileProviderTab;
-    if (const auto fileProviderWidgetTabIndex = tabWidget->indexOf(fileProviderTab); fileProviderWidgetTabIndex >= 0) {
-        tabWidget->removeTab(fileProviderWidgetTabIndex);
-    }
-    tabWidget->setCurrentIndex(0);
+    _ui->fileProviderPanel->setVisible(false);
 #endif
 
     const auto connectionSettingsTab = _ui->connectionSettingsTab;

--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -162,6 +162,37 @@
     </widget>
    </item>
    <item row="1" column="0">
+    <widget class="QFrame" name="fileProviderPanel">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <layout class="QVBoxLayout" name="fileProviderPanelLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="fileProviderPanelTitle">
+        <property name="text">
+         <string>Virtual file provider</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="fileProviderPanelContents" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
     <widget class="QFrame" name="accountTabsPanel">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
@@ -230,11 +261,6 @@
            </widget>
           </item>
          </layout>
-        </widget>
-        <widget class="QWidget" name="fileProviderTab">
-         <attribute name="title">
-          <string>Virtual file sync</string>
-         </attribute>
         </widget>
         <widget class="QWidget" name="connectionSettingsTab">
          <attribute name="title">

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -418,7 +418,7 @@ void SettingsDialog::customizeStyle()
 
         /* Panels */
         "#generalGroupBox, #advancedGroupBox, #aboutAndUpdatesGroupBox,"
-        "#accountStatusPanel, #accountTabsPanel {"
+        "#accountStatusPanel, #accountTabsPanel, #fileProviderPanel {"
         " background: palette(alternate-base);"
         " border-radius: 10px;"
         " margin: 0px;"


### PR DESCRIPTION
### Motivation
- Make the new Virtual File Provider section visually consistent with existing settings panels by giving it the same panel styling and a section heading.
- Ensure the embedded QML view stretches to the full panel width to remove the visible white gutter at the right edge.

### Description
- Added a `QFrame` named `fileProviderPanel` with a `QLabel` titled `Virtual file provider` and an inner `QWidget` `fileProviderPanelContents` in `src/gui/accountsettings.ui` and reset its layout margins to match other panels.
- Switched references in `src/gui/accountsettings.cpp` from the removed tab to `fileProviderPanelContents`, created a `QVBoxLayout` for it, set content margins/spacing to zero, set the contained QQuickWidget size policy to `QSizePolicy::Expanding` and changed the size mode to `QQuickWidget::SizeRootObjectToView` so the QML content stretches to the panel width.
- Marked `fileProviderPanelContents` to use styled background (`setAutoFillBackground` and `setAttribute(Qt::WA_StyledBackground, true)`) and kept the existing logic that hides `fileProviderPanel` when `BUILD_FILE_PROVIDER_MODULE` is not defined.
- Included `#fileProviderPanel` in the global panels selector in `src/gui/settingsdialog.cpp` so the new panel receives the same background and rounded-corner styling as other panels.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696edf20c57483339a6ed02947f2eb24)