### PR TITLE
fix: use alternate-base for connection settings background

### DIFF
--- a/src/gui/networksettings.cpp
+++ b/src/gui/networksettings.cpp
@@ -17,6 +17,7 @@
 #include <QNetworkProxy>
 #include <QString>
 #include <QList>
+#include <QPalette>
 #include <type_traits>
 
 namespace OCC {
@@ -27,6 +28,14 @@ NetworkSettings::NetworkSettings(const AccountPtr &account, QWidget *parent)
     , _account(account)
 {
     _ui->setupUi(this);
+    setAutoFillBackground(true);
+    setBackgroundRole(QPalette::AlternateBase);
+    _ui->proxyGroupBox->setAutoFillBackground(true);
+    _ui->proxyGroupBox->setBackgroundRole(QPalette::AlternateBase);
+    _ui->downloadBox->setAutoFillBackground(true);
+    _ui->downloadBox->setBackgroundRole(QPalette::AlternateBase);
+    _ui->uploadBox->setAutoFillBackground(true);
+    _ui->uploadBox->setBackgroundRole(QPalette::AlternateBase);
 
     _ui->manualSettings->setVisible(_ui->manualProxyRadioButton->isChecked());
 


### PR DESCRIPTION
### Motivation
- The Connection settings tab and its Proxy/Download/Upload sections used the wrong background color and should follow the theme `AlternateBase` palette role for consistent styling.

### Description
- Include `<QPalette>` and enable background filling on the `NetworkSettings` widget and on `_ui->proxyGroupBox`, `_ui->downloadBox`, and `_ui->uploadBox` by calling `setAutoFillBackground(true)` and `setBackgroundRole(QPalette::AlternateBase)`.

### Testing
- No automated tests were run for this UI styling change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f0c0d00c48333b99d5a33ca4aebec)