### PR TITLE
Use path-only DAV Destination header for chunked uploads and update tests

### DIFF
--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -79,9 +79,10 @@ QUrl PropagateUploadFileNG::chunkUrl(const int chunk) const
 
 QByteArray PropagateUploadFileNG::destinationHeader() const
 {
-    const auto davUrl = Utility::trailingSlashPath(propagator()->account()->davUrl().toString());
-    const auto remotePath = Utility::noLeadingSlashPath(propagator()->fullRemotePath(_fileToUpload._file));
-    const auto destination = QString(davUrl + remotePath);
+    // Keep this as an absolute DAV path (without scheme/host) so servers/proxies validating
+    // against the DAV base URI do not reject chunked uploads. Still percent-encode to preserve
+    // literal '%' in remote paths (e.g. "foo%BF") as "%25".
+    const auto destination = QDir::cleanPath(propagator()->account()->davUrl().path() + propagator()->fullRemotePath(_fileToUpload._file));
     return QUrl::toPercentEncoding(destination, "/");
 }
 

--- a/test/testchunkingng.cpp
+++ b/test/testchunkingng.cpp
@@ -151,6 +151,8 @@ private slots:
         QVERIFY(destinationHeader.contains("SQ-0.5%25BF-150"));
         QVERIFY(destinationHeader.contains("/A/SQ-0.5%25BF-150/"));
         QVERIFY(!destinationHeader.contains("%2F"));
+        QVERIFY(destinationHeader.startsWith("/remote.php/dav/files/"));
+        QVERIFY(!destinationHeader.contains("https%3A"));
     }
 
     // Test resuming when there's a confusing chunk added


### PR DESCRIPTION
### Motivation

- Some servers/proxies validate the DAV base URI and will reject `Destination` headers that include a scheme/host for chunked uploads. 
- Chunked upload code must preserve literal percent characters in remote paths (e.g. `foo%BF`) while avoiding percent-encoding the leading path separator. 
- Tests should verify the `Destination` header is an absolute DAV path and does not contain an encoded scheme.

### Description

- Change `PropagateUploadFileNG::destinationHeader()` to build the destination as a path-only DAV URI using `QDir::cleanPath(propagator()->account()->davUrl().path() + propagator()->fullRemotePath(...))` and then percent-encode with `QUrl::toPercentEncoding(destination, "/")`.
- Add a clarifying comment explaining why the header must be an absolute DAV path without scheme/host and that percent-encoding preserves literal `%` as `%25`.
- Update `test/testchunkingng.cpp` (`testDestinationHeaderPercentEncoding`) to assert the `Destination` header starts with the DAV path (e.g. `/remote.php/dav/files/`) and does not contain an encoded scheme like `https%3A`.

### Testing

- Ran the unit tests in `test/testchunkingng.cpp` including `testDestinationHeaderPercentEncoding`, and the updated assertions passed.
- Ran `testResume1` from the same test file to validate resume/delete behavior during chunking, and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af338688d08333aaabacfa49a01335)